### PR TITLE
Fix wrong indentation causing HDLC to always fail

### DIFF
--- a/Gurux.DLMS.python/gurux_dlms/GXDLMS.py
+++ b/Gurux.DLMS.python/gurux_dlms/GXDLMS.py
@@ -930,7 +930,7 @@ class GXDLMS:
             if settings.clientAddress != target:
                 if settings.clientAddress == source and settings.serverAddress == target:
                     reply.position = index + 1
-            return False
+                return False
             if settings.serverAddress != source:
                 readLogical = [0]
                 readPhysical = [0]


### PR DESCRIPTION
Fix issues that caused `checkHdlcAddress` to always return false.

The return was not inside the address check block causing `checkHdlcAddress` to always return False.