### PR TITLE
Fix `TypeError` in `GXDLMS`

### DIFF
--- a/Gurux.DLMS.python/gurux_dlms/GXDLMS.py
+++ b/Gurux.DLMS.python/gurux_dlms/GXDLMS.py
@@ -1219,14 +1219,14 @@ class GXDLMS:
             if data.data.position < data.data.size:
                 ret = data.data.getUInt8()
                 if ret == 0:
-                    cls.getDataFromBlock(data, 0)
+                    cls.getDataFromBlock(data.data, 0)
                 elif ret == 1:
                     ret = int(data.data.getUInt8())
                     if ret != 0:
                         data.error = data.data.getUInt8()
                         if ret == 9 and data.getError() == 16:
                             data.data.position = data.data.position - 2
-                            cls.getDataFromBlock(data, 0)
+                            cls.getDataFromBlock(data.data, 0)
                             data.error = 0
                             ret = 0
                     else:


### PR DESCRIPTION
`handleMethodResponse` was passing on `GXReplyData` instead of `GXByteBuffer` causing a `TypeError`

Fix use of `reply.data` instead of just `reply`.

```
....
  File "./venv/lib/python3.7/site-packages/gurux_dlms/GXDLMS.py", line 1198, in handleMethodResponse
    cls.getDataFromBlock(data, 0)
  File "./venv/lib/python3.7/site-packages/gurux_dlms/GXDLMS.py", line 1857, in getDataFromBlock
    if len(data) == data.position:
TypeError: object of type 'GXReplyData' has no len()
```

The relevant parts of the calling code:

```
reply = GXReplyData()
client = GXDLMSSecureClient(...)
disconnect = GXDLMSDisconnectControl(ln="0.0.96.3.10.255")
buf = client.method(disconnect, 2, int(0), DataType.INT8)
receive(request(buf, reply, timeout=1.0))
```