### PR TITLE
Add missing setter/getter for client address

### DIFF
--- a/Gurux.DLMS.python/gurux_dlms/GXDLMSSettings.py
+++ b/Gurux.DLMS.python/gurux_dlms/GXDLMSSettings.py
@@ -386,6 +386,19 @@ class GXDLMSSettings:
         self.sourceSystemTitle = value
 
     #
+    # @param value
+    # Set client address
+    #
+    def setClientAddress(self, value):
+        self.clientAddress = value
+
+    #
+    # Client address
+    #
+    def getClientAddress(self):
+        return self.clientAddress
+
+    #
     # Long data count.
     #
     def getCount(self):


### PR DESCRIPTION
Only `setClientAddress` is called from  `GXDLMS`.

If desired I can change PR to use the attribute directly instead of set/getters.