### PR TITLE
Fix issue where `.size` property is called as function

### DIFF
--- a/Gurux.DLMS.python/gurux_dlms/GXDLMS.py
+++ b/Gurux.DLMS.python/gurux_dlms/GXDLMS.py
@@ -1485,7 +1485,7 @@ class GXDLMS:
                         raise ValueError("Invalid block length.")
                     reply.command = (Command.NONE)
                 if blockLength == 0:
-                    data.size(index)
+                    data.size = index
                 else:
                     cls.getDataFromBlock(data, index)
                 if reply.moreData == RequestTypes.NONE:


### PR DESCRIPTION
`GXByteBuffer.size` is a property with getters and setters, calling it as function will break
as it calls the value returned from the getter (in this case an int).

This fixes it only in one place, there are 27 to a function named  with over half of them
seems to be used on a `GXByteBuffer` object.