### PR TITLE
Fix typo in getActions

### DIFF
--- a/Gurux.DLMS.python/gurux_dlms/objects/GXDLMSScriptTable.py
+++ b/Gurux.DLMS.python/gurux_dlms/objects/GXDLMSScriptTable.py
@@ -116,7 +116,7 @@ class GXDLMSScriptTable(GXDLMSObject, IGXDLMSBase):
                 data.setUInt8(DataType.ARRAY)
                 #  Count
                 data.setUInt8(len(it.actions))
-                for a in it.getActions:
+                for a in it.actions:
                     data.setUInt8(DataType.STRUCTURE)
                     data.setUInt8(5)
                     #  service_id


### PR DESCRIPTION
`GXDLMSScript` does not provide a getter for `actions`. Change to use attribute directly