### PR TITLE
Cast SortMethod to enum

### DIFF
--- a/Gurux.DLMS.python/gurux_dlms/objects/GXDLMSProfileGeneric.py
+++ b/Gurux.DLMS.python/gurux_dlms/objects/GXDLMSProfileGeneric.py
@@ -409,7 +409,7 @@ class GXDLMSProfileGeneric(GXDLMSObject, IGXDLMSBase):
             if e.value is None:
                 self.sortMethod = SortMethod.FIFO
             else:
-                self.sortMethod = e.value
+                self.sortMethod = SortMethod(e.value)
         elif e.index == 6:
             if settings and settings.isServer:
                 self.__reset()
@@ -548,7 +548,7 @@ class GXDLMSProfileGeneric(GXDLMSObject, IGXDLMSBase):
                 self.captureObjects.append((obj, co))
             reader.readEndElement("CaptureObjects")
         self.capturePeriod = reader.readElementContentAsInt("CapturePeriod")
-        self.sortMethod = reader.readElementContentAsInt("SortMethod")
+        self.sortMethod = SortMethod(reader.readElementContentAsInt("SortMethod"))
         if reader.isStartElement("SortObject", True):
             self.capturePeriod = reader.readElementContentAsInt("CapturePeriod")
             ot = reader.readElementContentAsInt("ObjectType")


### PR DESCRIPTION
Downloading from meter would return a GXEnum object instead of the expected SortMethod.

```
Traceback (most recent call last):
  ...
  File "/nix/store/cjkcj4zvpka3c8b1bhj94v7pcp6skrbi-python3-3.7.6-env/lib/python3.7/site-packages/gurux_dlms/objects/GXDLMSProfileGeneric.py", line 348, in getValue
    ret = self.sortMethod.value
AttributeError: 'GXEnum' object has no attribute 'value'
```