### PR TITLE
Fixed point scalers

### DIFF
--- a/Gurux.DLMS.python/gurux_dlms/objects/GXDLMSDemandRegister.py
+++ b/Gurux.DLMS.python/gurux_dlms/objects/GXDLMSDemandRegister.py
@@ -32,6 +32,7 @@
 #  Full text may be retrieved at http://www.gnu.org/licenses/gpl-2.0.txt
 # ---------------------------------------------------------------------------
 import math
+from decimal import Decimal
 import datetime
 from .GXDLMSObject import GXDLMSObject
 from .IGXDLMSBase import IGXDLMSBase
@@ -216,7 +217,9 @@ class GXDLMSDemandRegister(GXDLMSObject, IGXDLMSBase):
                     if settings.isServer:
                         self.currentAverageValue = e.value
                     else:
-                        self.currentAverageValue = e.value * self.scaler
+                        decimals = math.log10(self.scaler)
+                        self.currentAverageValue = round(
+                            Decimal(e.value) * Decimal(self.scaler), decimals)
                 except Exception:
                     #  Sometimes scaler is set for wrong Object type.
                     self.currentAverageValue = e.value

--- a/Gurux.DLMS.python/gurux_dlms/objects/GXDLMSExtendedRegister.py
+++ b/Gurux.DLMS.python/gurux_dlms/objects/GXDLMSExtendedRegister.py
@@ -32,6 +32,7 @@
 #  Full text may be retrieved at http://www.gnu.org/licenses/gpl-2.0.txt
 # ---------------------------------------------------------------------------
 import math
+from decimal import Decimal
 import datetime
 from .GXDLMSObject import GXDLMSObject
 from .IGXDLMSBase import IGXDLMSBase
@@ -169,7 +170,9 @@ class GXDLMSExtendedRegister(GXDLMSObject, IGXDLMSBase):
                     if settings.isServer:
                         self.value = e.value
                     else:
-                        self.value = e.value * self.scaler
+                        decimals = math.log10(self.scaler)
+                        self.value = round(
+                            Decimal(e.value) * Decimal(self.scaler), decimals)
                 except Exception:
                     #  Sometimes scaler is set for wrong Object type.
                     self.value = e.value

--- a/Gurux.DLMS.python/gurux_dlms/objects/GXDLMSObject.py
+++ b/Gurux.DLMS.python/gurux_dlms/objects/GXDLMSObject.py
@@ -89,7 +89,7 @@ class GXDLMSObject(object):
     # Is attribute read only.
     #
     def getLastReadTime(self, attributeIndex):
-        for k, v in self.readTimes:
+        for k, v in self.readTimes.items():
             if k == attributeIndex:
                 return v
         return None

--- a/Gurux.DLMS.python/gurux_dlms/objects/GXDLMSProfileGeneric.py
+++ b/Gurux.DLMS.python/gurux_dlms/objects/GXDLMSProfileGeneric.py
@@ -32,7 +32,8 @@
 #  Full text may be retrieved at http://www.gnu.org/licenses/gpl-2.0.txt
 # ---------------------------------------------------------------------------
 from __future__ import print_function
-from datetime import timedelta
+from decimal import Decimal
+import math
 from .GXDLMSObject import GXDLMSObject
 from .IGXDLMSBase import IGXDLMSBase
 from ..enums import ErrorCode
@@ -484,9 +485,13 @@ class GXDLMSProfileGeneric(GXDLMSObject, IGXDLMSBase):
                         scaler_ = item[0].scaler
                         if scaler_ != 1 and data:
                             try:
-                                row[colIndex] = data * scaler_
-                            except Exception:
-                                print("Scalar failed for: {}".format(item[0].logicalName))
+                                decimals = int(-1 * math.log10(scaler_))
+                                row[colIndex] = round(
+                                    Decimal(data) * Decimal(scaler_), decimals)
+                            except Exception as e2:
+                                print("Scalar failed for: {}".format(
+                                    item[0].logicalName))
+                                print("e", e2)
                     elif isinstance(item[0], GXDLMSDemandRegister) and (item[1].attributeIndex == 2 or item[1].attributeIndex == 3):
                         scaler_ = item[0].scaler
                         if scaler_ != 1 and data:

--- a/Gurux.DLMS.python/gurux_dlms/objects/GXDLMSProfileGeneric.py
+++ b/Gurux.DLMS.python/gurux_dlms/objects/GXDLMSProfileGeneric.py
@@ -409,7 +409,7 @@ class GXDLMSProfileGeneric(GXDLMSObject, IGXDLMSBase):
             if e.value is None:
                 self.sortMethod = SortMethod.FIFO
             else:
-                self.sortMethod = e.value
+                self.sortMethod = SortMethod(e.value)
         elif e.index == 6:
             if settings and settings.isServer:
                 self.__reset()
@@ -548,7 +548,7 @@ class GXDLMSProfileGeneric(GXDLMSObject, IGXDLMSBase):
                 self.captureObjects.append((obj, co))
             reader.readEndElement("CaptureObjects")
         self.capturePeriod = reader.readElementContentAsInt("CapturePeriod")
-        self.sortMethod = reader.readElementContentAsInt("SortMethod")
+        self.sortMethod = SortMethod(reader.readElementContentAsInt("SortMethod"))
         if reader.isStartElement("SortObject", True):
             self.capturePeriod = reader.readElementContentAsInt("CapturePeriod")
             ot = reader.readElementContentAsInt("ObjectType")

--- a/Gurux.DLMS.python/gurux_dlms/objects/GXDLMSRegister.py
+++ b/Gurux.DLMS.python/gurux_dlms/objects/GXDLMSRegister.py
@@ -32,6 +32,7 @@
 #  Full text may be retrieved at http://www.gnu.org/licenses/gpl-2.0.txt
 # ---------------------------------------------------------------------------
 import math
+from decimal import Decimal
 from .GXDLMSObject import GXDLMSObject
 from .IGXDLMSBase import IGXDLMSBase
 from ..enums import ErrorCode
@@ -152,7 +153,9 @@ class GXDLMSRegister(GXDLMSObject, IGXDLMSBase):
                     if settings.isServer:
                         self.value = e.value
                     else:
-                        self.value = e.value * self.scaler
+                        decimals = int(math.log10(self.scaler))
+                        self.value = round(
+                            Decimal(e.value) * Decimal(self.scaler), decimals)
                 except Exception:
                     #  Sometimes scaler is set for wrong Object type.
                     self.value = e.value


### PR DESCRIPTION
Use pythons `decimal` module for fixed point floating point calculation.

Using normal floating point arithmetic results in rounding errors like `2.345` being converted to `0.00023450000000000004`. Use `decimal` module and round to a specific number based on scaler.

Additionally fixes two bugs:
 *  `getLastReadTime` was iterating over dict without using `items()`  resulting in unpacking error
 * `sortMethod` was not casted correctly