### PR TITLE
Fixed listening_window attribute

### DIFF
--- a/Gurux.DLMS.python/gurux_dlms/objects/GXDLMSAutoAnswer.py
+++ b/Gurux.DLMS.python/gurux_dlms/objects/GXDLMSAutoAnswer.py
@@ -145,9 +145,9 @@ class GXDLMSAutoAnswer(GXDLMSObject, IGXDLMSBase):
                     #  Count
                     buff.setUInt8(2)
                     #  Start time
-                    _GXCommon.setData(settings, buff, DataType.OCTET_STRING, it.getKey())
+                    _GXCommon.setData(settings, buff, DataType.OCTET_STRING, it[0])
                     #  End time
-                    _GXCommon.setData(settings, buff, DataType.OCTET_STRING, it.value)
+                    _GXCommon.setData(settings, buff, DataType.OCTET_STRING, it[1])
             ret = buff.array()
         elif e.index == 4:
             ret = self.status


### PR DESCRIPTION
The attribute _listening_window_ of class _GXDLMSAutoAnswer_ , is sometimes treated as a list of tuples and other times as a list of dictionaries . Here I keep the first way.