### PR TITLE
decode n bytes

### DIFF
--- a/Gurux.DLMS.python/gurux_dlms/internal/_GXCommon.py
+++ b/Gurux.DLMS.python/gurux_dlms/internal/_GXCommon.py
@@ -1003,14 +1003,16 @@ class _GXCommon:
     # Returns parsed BCD value.
     #
     @classmethod
-    def getBcd(cls, buff, info):
+    def getBcd(cls, buff: GXByteBuffer, info):
         #  If there is not enough data available.
         if len(buff) - buff.position < 1:
             info.complete = False
             return None
-        value = buff.getUInt8()
+        count = buff.getUInt8()
+        value = buff.subArray(buff.position, count).hex()
+        buff.position += count
         if info.xml:
-            info.xml.appendLine(info.xml.getDataType(info.type_), None, info.xml.integerToHex(value, 2))
+            info.xml.appendLine(info.xml.getDataType(info.type_), None, value)
         return value
 
     #


### PR DESCRIPTION
to decode a bcd data type, requires to read "count" bytes from the buffer.
as the number of the bytes can be any length, its not safe to convert to an integer/decimal, it is safer to return a hex string and let this decision to the application.