### PR TITLE
Fix method call paramters to recive 4 param

### DIFF
--- a/Gurux.DLMS.python/gurux_dlms/objects/GXDLMSAccount.py
+++ b/Gurux.DLMS.python/gurux_dlms/objects/GXDLMSAccount.py
@@ -102,15 +102,15 @@ class GXDLMSAccount(GXDLMSObject, IGXDLMSBase):
 
     def activate(self, client):
         """Activate account."""
-        return client.method(self.getName(), self.objectType, 1, 0, DataType.INT8)
+        return client.method(self, 1, 0, DataType.INT8)
 
     def close(self, client):
         """Close account."""
-        return client.method(self.getName(), self.objectType, 2, 0, DataType.INT8)
+        return client.method(self, 2, 0, DataType.INT8)
 
     def reset(self, client):
         """Reset account."""
-        return client.method(self.getName(), self.objectType, 3, 0, DataType.INT8)
+        return client.method(self, 3, 0, DataType.INT8)
 
     #
     # Returns collection of attributes to read.  If attribute is static

--- a/Gurux.DLMS.python/gurux_dlms/objects/GXDLMSCredit.py
+++ b/Gurux.DLMS.python/gurux_dlms/objects/GXDLMSCredit.py
@@ -81,15 +81,15 @@ class GXDLMSCredit(GXDLMSObject, IGXDLMSBase):
 
     def updateAmount(self, client):
         """Adjusts the value of the current credit amount attribute."""
-        return client.method(self.getName(), self.objectType, 1, 0, DataType.INT8)
+        return client.method(self, 1, 0, DataType.INT8)
 
     def setAmountToValue(self, client, value):
         """Sets the value of the current credit amount attribute."""
-        return client.method(self.getName(), self.objectType, 2, value, DataType.INT32)
+        return client.method(self, 2, value, DataType.INT32)
 
     def invokeCredit(self, client, value):
         """Adjusts the value of the current credit amount attribute."""
-        return client.method(self.getName(), self.objectType, 3, value, DataType.UINT8)
+        return client.method(self, 3, value, DataType.UINT8)
 
     #
     # Returns collection of attributes to read.  If attribute is static and

--- a/Gurux.DLMS.python/gurux_dlms/objects/GXDLMSExtendedRegister.py
+++ b/Gurux.DLMS.python/gurux_dlms/objects/GXDLMSExtendedRegister.py
@@ -77,7 +77,7 @@ class GXDLMSExtendedRegister(GXDLMSObject, IGXDLMSBase):
 
     def reset(self, client):
         """Reset value."""
-        return client.method(self.getName(), self.objectType, 1, 0, DataType.INT8)
+        return client.method(self, 1, 0, DataType.INT8)
 
     def invoke(self, settings, e):
         #  Resets the value to the default value.

--- a/Gurux.DLMS.python/gurux_dlms/objects/GXDLMSLlcSscsSetup.py
+++ b/Gurux.DLMS.python/gurux_dlms/objects/GXDLMSLlcSscsSetup.py
@@ -62,7 +62,7 @@ class GXDLMSLlcSscsSetup(GXDLMSObject, IGXDLMSBase):
 
     def reset(self, client):
         """Reset value."""
-        return client.method(self.getName(), self.objectType, 1, 0, DataType.INT8)
+        return client.method(self, 1, 0, DataType.INT8)
 
     #
     # Returns collection of attributes to read.  If attribute is static and

--- a/Gurux.DLMS.python/gurux_dlms/objects/GXDLMSMBusClient.py
+++ b/Gurux.DLMS.python/gurux_dlms/objects/GXDLMSMBusClient.py
@@ -72,23 +72,23 @@ class GXDLMSMBusClient(GXDLMSObject, IGXDLMSBase):
 
     def slaveInstall(self, client):
         """Installs a slave device."""
-        return client.method(self.getName(), self.objectType, 1, 0, DataType.INT8)
+        return client.method(self, 1, 0, DataType.INT8)
 
     def slaveDeInstall(self, client):
         """De-installs a slave device."""
-        return client.method(self.getName(), self.objectType, 2, 0, DataType.INT8)
+        return client.method(self, 2, 0, DataType.INT8)
 
     def capture(self, client):
         """Captures values."""
-        return client.method(self.getName(), self.objectType, 3, 0, DataType.INT8)
+        return client.method(self, 3, 0, DataType.INT8)
 
     def resetAlarm(self, client):
         """Resets alarm state of the M-Bus slave device."""
-        return client.method(self.getName(), self.objectType, 4, 0, DataType.INT8)
+        return client.method(self, 4, 0, DataType.INT8)
 
     def synchronizeClock(self, client):
         """Synchronize the clock."""
-        return client.method(self.getName(), self.objectType, 5, 0, DataType.INT8)
+        return client.method(self, 5, 0, DataType.INT8)
 
     def sendData(self, client, data):
         """Sends data to the M-Bus slave device."""
@@ -106,7 +106,7 @@ class GXDLMSMBusClient(GXDLMSObject, IGXDLMSBase):
             _GXCommon.setObjectCount(it.ValueInformation.Length, bb)
             bb.set(it.ValueInformation)
             _GXCommon.setData(None, bb, _GXCommon.getDLMSDataType(it.Data), it.Data)
-        return client.method(self.getName(), self.objectType, 6, bb, DataType.ARRAY)
+        return client.method(self, 6, bb, DataType.ARRAY)
 
     def setEncryptionKey(self, client, encryptionKey):
         """Sets the encryption key in the M-Bus client and enables encrypted communication with the M-Bus slave device."""
@@ -117,7 +117,7 @@ class GXDLMSMBusClient(GXDLMSObject, IGXDLMSBase):
         else:
             _GXCommon.setObjectCount(encryptionKey.Length, bb)
             bb.set(encryptionKey)
-        return client.method(self.getName(), self.objectType, 7, bb, DataType.ARRAY)
+        return client.method(self, 7, bb, DataType.ARRAY)
 
     def transferKey(self, client, encryptionKey):
         """Transfers an encryption key to the M-Bus slave device."""
@@ -128,7 +128,7 @@ class GXDLMSMBusClient(GXDLMSObject, IGXDLMSBase):
         else:
             _GXCommon.setObjectCount(encryptionKey.Length, bb)
             bb.set(encryptionKey)
-        return client.method(self.getName(), self.objectType, 8, bb, DataType.ARRAY)
+        return client.method(self, 8, bb, DataType.ARRAY)
 
     def getValues(self):
         if self.version == 0:

--- a/Gurux.DLMS.python/gurux_dlms/objects/GXDLMSPrimeNbOfdmPlcMacCounters.py
+++ b/Gurux.DLMS.python/gurux_dlms/objects/GXDLMSPrimeNbOfdmPlcMacCounters.py
@@ -79,7 +79,7 @@ class GXDLMSPrimeNbOfdmPlcMacCounters(GXDLMSObject, IGXDLMSBase):
 
     def reset(self, client):
         """Reset all counters."""
-        return client.method(self.getName(), self.objectType, 1, 0, DataType.INT8)
+        return client.method(self, 1, 0, DataType.INT8)
 
     def invoke(self, settings, e):
         #  Resets the value to the default value.

--- a/Gurux.DLMS.python/gurux_dlms/objects/GXDLMSPrimeNbOfdmPlcMacNetworkAdministrationData.py
+++ b/Gurux.DLMS.python/gurux_dlms/objects/GXDLMSPrimeNbOfdmPlcMacNetworkAdministrationData.py
@@ -78,7 +78,7 @@ class GXDLMSPrimeNbOfdmPlcMacNetworkAdministrationData(GXDLMSObject, IGXDLMSBase
 
     def reset(self, client):
         """Reset the values."""
-        return client.method(self.getName(), self.objectType, 1, 0, DataType.INT8)
+        return client.method(self, 1, 0, DataType.INT8)
 
     def invoke(self, settings, e):
         #  Resets the value to the default value.

--- a/Gurux.DLMS.python/gurux_dlms/objects/GXDLMSPrimeNbOfdmPlcPhysicalLayerCounters.py
+++ b/Gurux.DLMS.python/gurux_dlms/objects/GXDLMSPrimeNbOfdmPlcPhysicalLayerCounters.py
@@ -74,7 +74,7 @@ class GXDLMSPrimeNbOfdmPlcPhysicalLayerCounters(GXDLMSObject, IGXDLMSBase):
 
     def reset(self, client):
         """Reset value."""
-        return client.method(self.getName(), self.objectType, 1, 0, DataType.INT8)
+        return client.method(self, 1, 0, DataType.INT8)
 
     def invoke(self, settings, e):
         #  Resets the value to the default value.

--- a/Gurux.DLMS.python/gurux_dlms/objects/GXDLMSPushSetup.py
+++ b/Gurux.DLMS.python/gurux_dlms/objects/GXDLMSPushSetup.py
@@ -108,7 +108,7 @@ class GXDLMSPushSetup(GXDLMSObject, IGXDLMSBase):
     # Activates the push process.
     #
     def activate(self, client):
-        return client.method(self.getName(), self.objectType, 1, 0, DataType.INT8)
+        return client.method(self, 1, 0, DataType.INT8)
 
     def getAttributeIndexToRead(self, all_):
         attributes = list()

--- a/Gurux.DLMS.python/gurux_dlms/objects/GXDLMSRegister.py
+++ b/Gurux.DLMS.python/gurux_dlms/objects/GXDLMSRegister.py
@@ -60,7 +60,7 @@ class GXDLMSRegister(GXDLMSObject, IGXDLMSBase):
 
     def reset(self, client):
         """Reset value."""
-        return client.method(self.getName(), self.objectType, 1, 0, DataType.INT8)
+        return client.method(self, 1, 0, DataType.INT8)
 
     def getValues(self):
         return [self.logicalName,


### PR DESCRIPTION
I found a bug for a lot of methods, some objects passes 5 param and the client.methods receives 4 params only, 
so i adjusted methods to receive 4 param by passing self instead of slef.name & self.type
