### PR TITLE
Remove broken `.xml` ref in `GXDLMSTranslator`

### DIFF
--- a/Gurux.DLMS.python/gurux_dlms/GXDLMSTranslator.py
+++ b/Gurux.DLMS.python/gurux_dlms/GXDLMSTranslator.py
@@ -1172,7 +1172,7 @@ class GXDLMSTranslator:
                             xml.endComment()
                 except Exception:
                     #  It's OK if this fails.  Ciphering settings are not correct.
-                    xml.xml.setXmlLength(len_)
+                    xml.setXmlLength(len_)
                 value.position = originalPosition
             cnt = _GXCommon.getObjectCount(value)
             if cnt != len(value) - value.position:


### PR DESCRIPTION
Remove broken reference to `.xml` attribute in `GXDLMSTranslator`.