### PR TITLE
fix: replace silent exception swallowing with logging and writeTrace

### DIFF
--- a/Gurux.DLMS.Client.Example.python/GXDLMSReader.py
+++ b/Gurux.DLMS.Client.Example.python/GXDLMSReader.py
@@ -475,8 +475,8 @@ class GXDLMSReader:
                             )
                 self.readByAccess(list_)
                 return
-        except Exception:
-            print("Failed to read scalers and units with access.")
+        except Exception as e:
+            self.writeTrace("Error! Failed to read scalers and units with access: " + str(e), TraceLevel.ERROR)
         try:
             if self.client.negotiatedConformance & Conformance.MULTIPLE_REFERENCES != 0:
                 for it in objs:

--- a/Gurux.DLMS.Client.Example.python/GXDLMSReader.py
+++ b/Gurux.DLMS.Client.Example.python/GXDLMSReader.py
@@ -123,9 +123,9 @@ class GXDLMSReader:
                     or self.client.ciphering.security != Security.NONE
                 ):
                     self.readDataBlock(self.client.releaseRequest(), reply)
-            except Exception:
-                pass
+            except Exception as e:
                 #  All meters don't support release.
+                self.writeTrace("Release request failed (meter may not support it): " + str(e), TraceLevel.WARNING)
 
     def close(self):
         # pylint: disable=broad-except
@@ -141,9 +141,9 @@ class GXDLMSReader:
                     or self.client.ciphering.security != Security.NONE
                 ):
                     self.readDataBlock(self.client.releaseRequest(), reply)
-            except Exception:
-                pass
+            except Exception as e:
                 #  All meters don't support release.
+                self.writeTrace("Release request failed (meter may not support it): " + str(e), TraceLevel.WARNING)
             reply.clear()
             self.readDLMSPacket(self.client.disconnectRequest(), reply)
             self.media.close()
@@ -498,8 +498,8 @@ class GXDLMSReader:
                     elif isinstance(it, (GXDLMSDemandRegister,)):
                         if it.canRead(4):
                             self.read(it, 4)
-                except Exception:
-                    pass
+                except Exception as e:
+                    self.writeTrace("Failed to read scaler/unit for " + str(it.name) + ": " + str(e), TraceLevel.WARNING)
 
     def getProfileGenericColumns(self):
         # pylint: disable=broad-except

--- a/Gurux.DLMS.Client.Example.python/GXDLMSReader.py
+++ b/Gurux.DLMS.Client.Example.python/GXDLMSReader.py
@@ -125,7 +125,7 @@ class GXDLMSReader:
                     self.readDataBlock(self.client.releaseRequest(), reply)
             except Exception as e:
                 #  All meters don't support release.
-                self.writeTrace("Release request failed (meter may not support it): " + str(e), TraceLevel.WARNING)
+                self.writeTrace("Release request failed (meter may not support it): " + str(e), TraceLevel.INFO)
 
     def close(self):
         # pylint: disable=broad-except
@@ -143,7 +143,7 @@ class GXDLMSReader:
                     self.readDataBlock(self.client.releaseRequest(), reply)
             except Exception as e:
                 #  All meters don't support release.
-                self.writeTrace("Release request failed (meter may not support it): " + str(e), TraceLevel.WARNING)
+                self.writeTrace("Release request failed (meter may not support it): " + str(e), TraceLevel.INFO)
             reply.clear()
             self.readDLMSPacket(self.client.disconnectRequest(), reply)
             self.media.close()
@@ -499,7 +499,7 @@ class GXDLMSReader:
                         if it.canRead(4):
                             self.read(it, 4)
                 except Exception as e:
-                    self.writeTrace("Failed to read scaler/unit for " + str(it.name) + ": " + str(e), TraceLevel.WARNING)
+                    self.writeTrace("Error! Failed to read scaler/unit for " + str(it.name) + ": " + str(e), TraceLevel.ERROR)
 
     def getProfileGenericColumns(self):
         # pylint: disable=broad-except

--- a/Gurux.DLMS.python/gurux_dlms/GXDLMSTranslator.py
+++ b/Gurux.DLMS.python/gurux_dlms/GXDLMSTranslator.py
@@ -32,6 +32,7 @@
 #  Full text may be retrieved at http://www.gnu.org/licenses/gpl-2.0.txt
 # ---------------------------------------------------------------------------
 from __future__ import print_function
+import logging
 import xml.etree.cElementTree as ET
 from .internal._GXCommon import _GXCommon
 from .GXByteBuffer import GXByteBuffer
@@ -85,6 +86,9 @@ from .plc.enums import PlcSourceAddress, PlcDestinationAddress
 
 
 # pylint:disable=bad-option-value,too-many-instance-attributes,too-many-function-args,too-many-public-methods,too-many-public-methods,too-many-function-args,too-many-instance-attributes,old-style-class,raise-missing-from
+
+logger = logging.getLogger(__name__)
+
 class GXDLMSTranslator:
     """
     This class is used to translate DLMS frame or PDU to xml.
@@ -1172,6 +1176,7 @@ class GXDLMSTranslator:
                             xml.endComment()
                 except Exception:
                     #  It's OK if this fails.  Ciphering settings are not correct.
+                    logger.debug("Failed to decrypt GLO_CIPHERING data for XML comment", exc_info=True)
                     xml.xml.setXmlLength(len_)
                 value.position = originalPosition
             cnt = _GXCommon.getObjectCount(value)
@@ -1209,6 +1214,7 @@ class GXDLMSTranslator:
                 except Exception:
                     #  It's OK if this fails.  Ciphering settings are not
                     #  correct.
+                    logger.debug("Failed to decrypt GENERAL_GLO_CIPHERING data for XML comment", exc_info=True)
                     xml.setXmlLength(len_)
                 value.position = originalPosition
             len_ = _GXCommon.getObjectCount(value)

--- a/Gurux.DLMS.python/gurux_dlms/objects/GXDLMSObjectCollection.py
+++ b/Gurux.DLMS.python/gurux_dlms/objects/GXDLMSObjectCollection.py
@@ -255,7 +255,8 @@ class GXDLMSObjectCollection(list):
         xml_bytes = ET.tostring(objects, encoding="utf-8", method="xml")
         # Muuta merkkijonoksi ja tulosta tarkastelua varten
         xml_str = xml_bytes.decode("utf-8")
-        print(repr(xml_str))  # repr näyttää myös piilomerkit kuten \n, \t jne.
+        print(repr(xml_str))  # repr shows hidden characters
+
 
 
         str_ = minidom.parseString(

--- a/Gurux.DLMS.python/setup.cfg
+++ b/Gurux.DLMS.python/setup.cfg
@@ -1,0 +1,2 @@
+[tool:pytest]
+testpaths = tests

--- a/Gurux.DLMS.python/tests/test_translator_logging.py
+++ b/Gurux.DLMS.python/tests/test_translator_logging.py
@@ -1,10 +1,11 @@
 import logging
-from unittest.mock import patch, MagicMock
-import sys
 import os
+import sys
+from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
+from gurux_dlms.GXByteBuffer import GXByteBuffer
 from gurux_dlms.GXDLMSTranslator import GXDLMSTranslator
 
 
@@ -12,6 +13,7 @@ def test_decrypt_failure_for_glo_ciphering_comment_is_logged(caplog):
     """When decryption fails during GLO_CIPHERING comment generation,
     a debug log message should be emitted instead of silently swallowing
     the exception."""
+    # Command.GLO_GET_REQUEST = 0xC8 triggers the GLO ciphering branch in _pduToXml2
     translator = GXDLMSTranslator()
     translator.comments = True
 
@@ -20,15 +22,8 @@ def test_decrypt_failure_for_glo_ciphering_comment_is_logged(caplog):
         side_effect=Exception("Decryption failed: invalid key")
     ):
         with caplog.at_level(logging.DEBUG, logger='gurux_dlms.GXDLMSTranslator'):
-            mock_cipher = MagicMock()
-            mock_cipher.blockCipherKey = b'\x00' * 16
-            mock_cipher.authenticationKey = b'\x00' * 16
-            mock_cipher.systemTitle = b'\x00' * 8
-
-            from gurux_dlms.GXByteBuffer import GXByteBuffer
-
             value = GXByteBuffer()
-            value.set(bytearray([0x00, 0x01, 0x00]))
+            value.set(bytearray([0xC8, 0x01, 0x00]))
 
             try:
                 translator._pduToXml2(MagicMock(), value, True, True, False)
@@ -45,6 +40,7 @@ def test_decrypt_failure_for_glo_ciphering_comment_is_logged(caplog):
 def test_decrypt_failure_for_general_glo_ciphering_comment_is_logged(caplog):
     """When decryption fails during GENERAL_GLO_CIPHERING comment generation,
     a debug log message should be emitted."""
+    # Command.GENERAL_GLO_CIPHERING = 0xDB triggers the general GLO ciphering branch
     translator = GXDLMSTranslator()
     translator.comments = True
 
@@ -53,15 +49,8 @@ def test_decrypt_failure_for_general_glo_ciphering_comment_is_logged(caplog):
         side_effect=Exception("Decryption failed: invalid key")
     ):
         with caplog.at_level(logging.DEBUG, logger='gurux_dlms.GXDLMSTranslator'):
-            mock_cipher = MagicMock()
-            mock_cipher.blockCipherKey = b'\x00' * 16
-            mock_cipher.authenticationKey = b'\x00' * 16
-            mock_cipher.systemTitle = b'\x00' * 8
-
-            from gurux_dlms.GXByteBuffer import GXByteBuffer
-
             value = GXByteBuffer()
-            value.set(bytearray([0x00, 0x01, 0x00]))
+            value.set(bytearray([0xDB, 0x01, 0x00]))
 
             try:
                 translator._pduToXml2(MagicMock(), value, True, True, False)

--- a/Gurux.DLMS.python/tests/test_translator_logging.py
+++ b/Gurux.DLMS.python/tests/test_translator_logging.py
@@ -1,0 +1,75 @@
+import logging
+from unittest.mock import patch, MagicMock
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from gurux_dlms.GXDLMSTranslator import GXDLMSTranslator
+
+
+def test_decrypt_failure_for_glo_ciphering_comment_is_logged(caplog):
+    """When decryption fails during GLO_CIPHERING comment generation,
+    a debug log message should be emitted instead of silently swallowing
+    the exception."""
+    translator = GXDLMSTranslator()
+    translator.comments = True
+
+    with patch(
+        'gurux_dlms.GXDLMSTranslator.GXCiphering.decrypt',
+        side_effect=Exception("Decryption failed: invalid key")
+    ):
+        with caplog.at_level(logging.DEBUG, logger='gurux_dlms.GXDLMSTranslator'):
+            mock_cipher = MagicMock()
+            mock_cipher.blockCipherKey = b'\x00' * 16
+            mock_cipher.authenticationKey = b'\x00' * 16
+            mock_cipher.systemTitle = b'\x00' * 8
+
+            from gurux_dlms.GXByteBuffer import GXByteBuffer
+
+            value = GXByteBuffer()
+            value.set(bytearray([0x00, 0x01, 0x00]))
+
+            try:
+                translator._pduToXml2(MagicMock(), value, True, True, False)
+            except Exception:
+                pass
+
+    assert any(
+        "decrypt" in record.message.lower() or "cipher" in record.message.lower()
+        for record in caplog.records
+        if record.levelno == logging.DEBUG
+    ), "Expected a debug log message about decryption failure, but none was found"
+
+
+def test_decrypt_failure_for_general_glo_ciphering_comment_is_logged(caplog):
+    """When decryption fails during GENERAL_GLO_CIPHERING comment generation,
+    a debug log message should be emitted."""
+    translator = GXDLMSTranslator()
+    translator.comments = True
+
+    with patch(
+        'gurux_dlms.GXDLMSTranslator.GXCiphering.decrypt',
+        side_effect=Exception("Decryption failed: invalid key")
+    ):
+        with caplog.at_level(logging.DEBUG, logger='gurux_dlms.GXDLMSTranslator'):
+            mock_cipher = MagicMock()
+            mock_cipher.blockCipherKey = b'\x00' * 16
+            mock_cipher.authenticationKey = b'\x00' * 16
+            mock_cipher.systemTitle = b'\x00' * 8
+
+            from gurux_dlms.GXByteBuffer import GXByteBuffer
+
+            value = GXByteBuffer()
+            value.set(bytearray([0x00, 0x01, 0x00]))
+
+            try:
+                translator._pduToXml2(MagicMock(), value, True, True, False)
+            except Exception:
+                pass
+
+    assert any(
+        "decrypt" in record.message.lower() or "cipher" in record.message.lower()
+        for record in caplog.records
+        if record.levelno == logging.DEBUG
+    ), "Expected a debug log message about decryption failure, but none was found"

--- a/docs/plans/2026-02-20-fix-silent-exceptions-design.md
+++ b/docs/plans/2026-02-20-fix-silent-exceptions-design.md
@@ -1,0 +1,60 @@
+# Design: Fix Silent Exception Swallowing
+
+**Date:** 2026-02-20
+**Scope:** `GXDLMSTranslator.py` (library) + `GXDLMSReader.py` (example)
+
+---
+
+## Problem
+
+Several `except` blocks in the codebase swallow exceptions silently — either with bare
+`pass` or with no diagnostic output. This makes debugging meter communication failures
+very difficult because errors vanish without a trace.
+
+---
+
+## Findings
+
+Most `pass` statements in `GXDLMSTranslator.py` are **intentional no-ops** in large
+if-elif tag routing chains (XML tag dispatch). These are correct and are not changed.
+
+The actual silent exception sites are:
+
+| File | Lines | Context |
+|---|---|---|
+| `GXDLMSTranslator.py` | ~1173, ~1209 | Decryption attempt for inline XML comment output fails silently |
+| `GXDLMSReader.py` | ~126–127, ~144–145 | Release request on disconnect — not all meters support it |
+| `GXDLMSReader.py` | ~501–502 | Reading individual register scaler/unit attribute fails silently |
+
+---
+
+## Approach: Add logging (no behavioral change)
+
+### Library — `GXDLMSTranslator.py`
+
+- Add `import logging` and `logger = logging.getLogger(__name__)` at module level.
+- In each silent decrypt-attempt except block, add `logger.debug(...)` with `exc_info=True`
+  before the existing XML-rollback line.
+- The rollback behavior is preserved. The change only makes the failure observable when
+  the caller enables debug logging.
+
+### Examples — `GXDLMSReader.py`
+
+- The example already uses `self.writeTrace(message, TraceLevel.X)` for all output.
+- Replace each bare `except Exception: pass` with a `self.writeTrace("...", TraceLevel.WARNING)`
+  call to stay consistent with the existing pattern.
+
+---
+
+## Non-goals
+
+- Do not touch `pass` statements inside if-elif chains — they are correct.
+- Do not change error-handling in other files (separate contribution).
+- Do not introduce a `strict` mode flag — out of scope for this change.
+
+---
+
+## Files Changed
+
+1. `Gurux.DLMS.python/gurux_dlms/GXDLMSTranslator.py`
+2. `Gurux.DLMS.Client.Example.python/GXDLMSReader.py`

--- a/docs/plans/2026-02-20-fix-silent-exceptions.md
+++ b/docs/plans/2026-02-20-fix-silent-exceptions.md
@@ -1,0 +1,390 @@
+# Fix Silent Exception Swallowing Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace bare `except: pass` blocks in `GXDLMSTranslator.py` and `GXDLMSReader.py` with proper logging and `writeTrace` calls so failures become observable.
+
+**Architecture:** Library code uses Python's `logging` module with `logger.debug(..., exc_info=True)` — zero behavioral change, failures become visible when the caller enables debug logging. Example app code uses the existing `self.writeTrace()` pattern already present throughout `GXDLMSReader.py`.
+
+**Tech Stack:** Python 3, `logging` (stdlib), `pytest`, `unittest.mock`
+
+---
+
+## Context
+
+There are no existing tests in this repo. We bootstrap a minimal pytest setup in Task 1.
+
+The silent exception sites are:
+
+| File | Lines | Context |
+|---|---|---|
+| `GXDLMSTranslator.py` | 1173–1175 | Decryption attempt for GLO_CIPHERING XML comment |
+| `GXDLMSTranslator.py` | 1209–1212 | Decryption attempt for GENERAL_GLO_CIPHERING XML comment |
+| `GXDLMSReader.py` | 126–127 | `release()` — release request; not all meters support it |
+| `GXDLMSReader.py` | 144–145 | `close()` — same release request pattern |
+| `GXDLMSReader.py` | 501–502 | Reading individual register scaler/unit attribute |
+
+All other `pass` statements in `GXDLMSTranslator.py` are in if-elif tag routing chains and are intentional — do not touch them.
+
+---
+
+### Task 1: Bootstrap pytest infrastructure
+
+**Files:**
+- Create: `Gurux.DLMS.python/tests/__init__.py`
+- Create: `Gurux.DLMS.python/tests/test_translator_logging.py`
+- Create: `Gurux.DLMS.python/setup.cfg`
+
+**Step 1: Install pytest (if not already installed)**
+
+```bash
+pip install pytest
+```
+
+Expected: `Successfully installed pytest-...` or `Requirement already satisfied`
+
+**Step 2: Create the tests package**
+
+```bash
+mkdir -p Gurux.DLMS.python/tests
+touch Gurux.DLMS.python/tests/__init__.py
+```
+
+**Step 3: Create `setup.cfg` so pytest can find the package**
+
+Create `Gurux.DLMS.python/setup.cfg`:
+
+```ini
+[tool:pytest]
+testpaths = tests
+```
+
+**Step 4: Write the failing test for translator logging**
+
+Create `Gurux.DLMS.python/tests/test_translator_logging.py`:
+
+```python
+import logging
+from unittest.mock import patch, MagicMock
+import sys
+import os
+
+# Make sure the library is importable from the tests directory
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from gurux_dlms.GXDLMSTranslator import GXDLMSTranslator
+
+
+def test_decrypt_failure_for_glo_ciphering_comment_is_logged(caplog):
+    """When decryption fails during GLO_CIPHERING comment generation,
+    a debug log message should be emitted instead of silently swallowing
+    the exception."""
+    translator = GXDLMSTranslator()
+    translator.comments = True
+
+    # Patch GXCiphering.decrypt to raise an exception (simulates wrong keys)
+    with patch(
+        'gurux_dlms.GXDLMSTranslator.GXCiphering.decrypt',
+        side_effect=Exception("Decryption failed: invalid key")
+    ):
+        with caplog.at_level(logging.DEBUG, logger='gurux_dlms.GXDLMSTranslator'):
+            # Build minimal cipher context so the code reaches the decrypt call
+            mock_cipher = MagicMock()
+            mock_cipher.blockCipherKey = b'\x00' * 16
+            mock_cipher.authenticationKey = b'\x00' * 16
+            mock_cipher.systemTitle = b'\x00' * 8
+
+            # Call the internal method that contains the silent except block.
+            # We use a minimal GXDLMSXmlSettings-like object.
+            from gurux_dlms.GXDLMSSettings import GXDLMSSettings
+            settings = GXDLMSSettings(True)
+            settings.cipher = mock_cipher
+
+            xml = MagicMock()
+            xml.getXmlLength.return_value = 0
+
+            from gurux_dlms.GXByteBuffer import GXByteBuffer
+            from gurux_dlms.enums import Command
+
+            value = GXByteBuffer()
+            # Minimal GLO_CIPHERING payload (security byte + length + data)
+            value.set(bytearray([0x00, 0x01, 0x00]))
+
+            try:
+                translator._pduToXml2(xml, value, True, True, False)
+            except Exception:
+                pass  # We only care that the log was emitted, not the parse result
+
+    assert any(
+        "decrypt" in record.message.lower() or "cipher" in record.message.lower()
+        for record in caplog.records
+        if record.levelno == logging.DEBUG
+    ), "Expected a debug log message about decryption failure, but none was found"
+
+
+def test_decrypt_failure_for_general_glo_ciphering_comment_is_logged(caplog):
+    """Same as above but for the GENERAL_GLO_CIPHERING branch."""
+    translator = GXDLMSTranslator()
+    translator.comments = True
+
+    with patch(
+        'gurux_dlms.GXDLMSTranslator.GXCiphering.decrypt',
+        side_effect=Exception("Decryption failed: invalid key")
+    ):
+        with caplog.at_level(logging.DEBUG, logger='gurux_dlms.GXDLMSTranslator'):
+            mock_cipher = MagicMock()
+            mock_cipher.blockCipherKey = b'\x00' * 16
+            mock_cipher.authenticationKey = b'\x00' * 16
+            mock_cipher.systemTitle = b'\x00' * 8
+
+            from gurux_dlms.GXDLMSSettings import GXDLMSSettings
+            settings = GXDLMSSettings(True)
+            settings.cipher = mock_cipher
+
+            xml = MagicMock()
+            xml.getXmlLength.return_value = 0
+
+            from gurux_dlms.GXByteBuffer import GXByteBuffer
+
+            value = GXByteBuffer()
+            value.set(bytearray([0x00, 0x01, 0x00]))
+
+            try:
+                translator._pduToXml2(xml, value, True, True, False)
+            except Exception:
+                pass
+
+    assert any(
+        "decrypt" in record.message.lower() or "cipher" in record.message.lower()
+        for record in caplog.records
+        if record.levelno == logging.DEBUG
+    ), "Expected a debug log message about decryption failure, but none was found"
+```
+
+**Step 5: Run the test to confirm it FAILS**
+
+```bash
+cd Gurux.DLMS.python && pytest tests/test_translator_logging.py -v
+```
+
+Expected: Both tests FAIL — `AssertionError: Expected a debug log message ...`
+
+**Step 6: Commit the test setup**
+
+```bash
+git add Gurux.DLMS.python/tests/ Gurux.DLMS.python/setup.cfg
+git commit -m "test: bootstrap pytest and add failing tests for translator logging"
+```
+
+---
+
+### Task 2: Add logging to `GXDLMSTranslator.py`
+
+**Files:**
+- Modify: `Gurux.DLMS.python/gurux_dlms/GXDLMSTranslator.py:34` (add import)
+- Modify: `Gurux.DLMS.python/gurux_dlms/GXDLMSTranslator.py:87` (add module logger)
+- Modify: `Gurux.DLMS.python/gurux_dlms/GXDLMSTranslator.py:1173` (first except block)
+- Modify: `Gurux.DLMS.python/gurux_dlms/GXDLMSTranslator.py:1209` (second except block)
+
+**Step 1: Add `import logging` after the existing imports**
+
+In `GXDLMSTranslator.py`, find the line:
+
+```python
+from __future__ import print_function
+import xml.etree.cElementTree as ET
+```
+
+Add `import logging` immediately after the `import xml.etree.cElementTree as ET` line:
+
+```python
+from __future__ import print_function
+import logging
+import xml.etree.cElementTree as ET
+```
+
+**Step 2: Add the module-level logger just before the class definition**
+
+The class definition is at line 88: `class GXDLMSTranslator:`. Add one line immediately above it:
+
+```python
+logger = logging.getLogger(__name__)
+
+
+class GXDLMSTranslator:
+```
+
+**Step 3: Fix the first silent except block (GLO_CIPHERING, ~line 1173)**
+
+Find this exact block:
+
+```python
+                except Exception:
+                    #  It's OK if this fails.  Ciphering settings are not correct.
+                    xml.xml.setXmlLength(len_)
+```
+
+Replace with:
+
+```python
+                except Exception:
+                    #  It's OK if this fails.  Ciphering settings are not correct.
+                    logger.debug("Failed to decrypt GLO_CIPHERING data for XML comment", exc_info=True)
+                    xml.xml.setXmlLength(len_)
+```
+
+**Step 4: Fix the second silent except block (GENERAL_GLO_CIPHERING, ~line 1209)**
+
+Find this exact block:
+
+```python
+                except Exception:
+                    #  It's OK if this fails.  Ciphering settings are not
+                    #  correct.
+                    xml.setXmlLength(len_)
+```
+
+Replace with:
+
+```python
+                except Exception:
+                    #  It's OK if this fails.  Ciphering settings are not
+                    #  correct.
+                    logger.debug("Failed to decrypt GENERAL_GLO_CIPHERING data for XML comment", exc_info=True)
+                    xml.setXmlLength(len_)
+```
+
+**Step 5: Run the tests — they should now PASS**
+
+```bash
+cd Gurux.DLMS.python && pytest tests/test_translator_logging.py -v
+```
+
+Expected output:
+```
+PASSED tests/test_translator_logging.py::test_decrypt_failure_for_glo_ciphering_comment_is_logged
+PASSED tests/test_translator_logging.py::test_decrypt_failure_for_general_glo_ciphering_comment_is_logged
+```
+
+**Step 6: Commit**
+
+```bash
+git add Gurux.DLMS.python/gurux_dlms/GXDLMSTranslator.py
+git commit -m "fix: log decryption failures in GXDLMSTranslator instead of silently swallowing"
+```
+
+---
+
+### Task 3: Fix silent exceptions in `GXDLMSReader.py`
+
+Note: `GXDLMSReader.py` is an example application that requires a live media connection to test end-to-end. We do not write unit tests for it. The fix is mechanical — replace `pass` with `self.writeTrace(...)` to match the existing pattern used throughout the file.
+
+**Files:**
+- Modify: `Gurux.DLMS.Client.Example.python/GXDLMSReader.py:126`
+- Modify: `Gurux.DLMS.Client.Example.python/GXDLMSReader.py:144`
+- Modify: `Gurux.DLMS.Client.Example.python/GXDLMSReader.py:501`
+
+**Step 1: Fix `release()` — lines 125–128**
+
+Find this exact block in `GXDLMSReader.py`:
+
+```python
+            except Exception:
+                pass
+                #  All meters don't support release.
+```
+
+(This is in the `release()` method, around line 126.)
+
+Replace with:
+
+```python
+            except Exception as e:
+                #  All meters don't support release.
+                self.writeTrace("Release request failed (meter may not support it): " + str(e), TraceLevel.WARNING)
+```
+
+**Step 2: Fix `close()` — lines 143–146**
+
+Find the identical block in the `close()` method (around line 144):
+
+```python
+            except Exception:
+                pass
+                #  All meters don't support release.
+```
+
+Replace with:
+
+```python
+            except Exception as e:
+                #  All meters don't support release.
+                self.writeTrace("Release request failed (meter may not support it): " + str(e), TraceLevel.WARNING)
+```
+
+**Step 3: Fix `readScalerAndUnits()` — lines 500–502**
+
+Find this block (around line 501):
+
+```python
+                except Exception:
+                    pass
+```
+
+Replace with:
+
+```python
+                except Exception as e:
+                    self.writeTrace("Failed to read scaler/unit for " + str(it.name) + ": " + str(e), TraceLevel.WARNING)
+```
+
+**Step 4: Verify the file is syntactically correct**
+
+```bash
+python -m py_compile Gurux.DLMS.Client.Example.python/GXDLMSReader.py && echo "OK"
+```
+
+Expected: `OK`
+
+**Step 5: Run all tests to make sure nothing broke**
+
+```bash
+cd Gurux.DLMS.python && pytest tests/ -v
+```
+
+Expected: All tests PASS.
+
+**Step 6: Commit**
+
+```bash
+git add Gurux.DLMS.Client.Example.python/GXDLMSReader.py
+git commit -m "fix: replace silent exception swallowing in GXDLMSReader with writeTrace warnings"
+```
+
+---
+
+### Task 4: Final verification
+
+**Step 1: Run the full test suite one last time**
+
+```bash
+cd Gurux.DLMS.python && pytest tests/ -v
+```
+
+Expected: All tests PASS, no warnings about missing imports.
+
+**Step 2: Verify the translator's logging name is correct**
+
+```bash
+python -c "from gurux_dlms.GXDLMSTranslator import GXDLMSTranslator; import logging; logging.basicConfig(level=logging.DEBUG); t = GXDLMSTranslator(); print('Import OK')"
+```
+
+Expected: `Import OK`
+
+**Step 3: Commit if clean**
+
+```bash
+git status
+```
+
+If nothing extra is staged, you're done. If any stray files appeared, investigate before committing.


### PR DESCRIPTION
## Summary

- **`GXDLMSTranslator.py`**: Added `import logging` and a module-level `logger = logging.getLogger(__name__)`. The two `except Exception` blocks in the GLO ciphering and GENERAL_GLO_CIPHERING XML comment paths now call `logger.debug(..., exc_info=True)` before the existing XML-rollback line, making decryption failures visible when debug logging is enabled. Behaviour is unchanged — the rollback still happens, the exception is still swallowed — but failures are no longer invisible.

- **`GXDLMSReader.py`**: Replaced four bare `except Exception: pass` / `print()` blocks with `self.writeTrace()` calls at appropriate trace levels:
  - `release()` and `close()` release-request failures → `TraceLevel.INFO` (expected; not all meters support release)
  - `readScalerAndUnits()` per-object read failure → `TraceLevel.ERROR` (consistent with identical failures elsewhere in the file)
  - `readScalerAndUnits()` access-service failure → `TraceLevel.ERROR` (was a bare `print()` that discarded the exception)

- **`tests/`**: Bootstrapped pytest infrastructure (`setup.cfg`, `tests/__init__.py`) and added two unit tests that verify `logger.debug` is called when `GXCiphering.decrypt` raises — one test per code path (`GLO_CIPHERING` and `GENERAL_GLO_CIPHERING`).

## Test plan

- [ ] `cd Gurux.DLMS.python && pytest tests/ -v` → 2 passed
- [ ] `python3 -m py_compile Gurux.DLMS.Client.Example.python/GXDLMSReader.py` → OK
- [ ] Enable `logging.basicConfig(level=logging.DEBUG)` in a client session with wrong cipher keys — decryption failure now appears in the log instead of silently disappearing

🤖 Generated with [Claude Code](https://claude.com/claude-code)